### PR TITLE
UC2

### DIFF
--- a/.github/workflows/test-dismiss.yaml
+++ b/.github/workflows/test-dismiss.yaml
@@ -51,5 +51,5 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           # no-owner-action: dismiss-none
-          # force-push-action: dismiss-none
+          force-push-action: dismiss-none
           #ignore-files: |

--- a/Test-folder-2-COG-2/test-file-2-COG-2.txt
+++ b/Test-folder-2-COG-2/test-file-2-COG-2.txt
@@ -1,0 +1,1 @@
+Add line 1

--- a/no-COG-file.txt
+++ b/no-COG-file.txt
@@ -1,0 +1,1 @@
+Add line 1

--- a/no-COG-file.txt
+++ b/no-COG-file.txt
@@ -1,1 +1,2 @@
 Add line 1
+Add line 2


### PR DESCRIPTION
Approved reviews are NOT dismissed when force-pushed changes don’t have a codeowner and the no-owner-action setting is set to dismiss-all